### PR TITLE
Borrow request simplification

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -21,7 +21,6 @@ model Game {
     playtimeMinutes Int // Stored in minutes @map("playtime")
     location        String
     playStatus      PlayStatus[]
-    borrow          Borrow[]
     request         BorrowRequest[]
     GameOwner       GameOwner?      @relation(fields: [gameOwnerId], references: [id], onDelete: Cascade)
     gameOwnerId     String?
@@ -100,33 +99,24 @@ model GameOwner {
     @@map("game_owners")
 }
 
-model Borrow {
-    game        Game     @relation(fields: [gameId], references: [id], onDelete: Cascade)
-    id          String   @id @default(cuid())
-    gameId      String
-    user        String
-    borrowStart DateTime
-    borrowEnd   DateTime
-    returned    Boolean  @default(false)
-
-    @@map("borrows")
-}
-
 enum BorrowRequestStatus {
     PENDING
     ACCEPTED
     REJECTED
+    BORROWED
+    RETURNED
 }
 
 model BorrowRequest {
     game        Game                @relation(fields: [gameId], references: [id], onDelete: Cascade)
+    id          String              @id @default(cuid())
     gameId      String
     user        String
     borrowStart DateTime
     borrowEnd   DateTime
     status      BorrowRequestStatus @default(PENDING)
 
-    @@id([gameId, borrowStart, borrowEnd])
+    @@unique([gameId, borrowStart, borrowEnd], name: "borrow_request_identifier")
     @@map("borrow_requests")
 }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -54,6 +54,7 @@ model User {
     organizationsMember OrganizationMember[]
     ratings             Rating[]
     playStatus          PlayStatus[]
+    borrowRequests      BorrowRequest[]
 
     @@map("users")
 }
@@ -111,7 +112,8 @@ model BorrowRequest {
     game        Game                @relation(fields: [gameId], references: [id], onDelete: Cascade)
     id          String              @id @default(cuid())
     gameId      String
-    user        String
+    user        User                @relation(fields: [userId], references: [id])
+    userId      String
     borrowStart DateTime
     borrowEnd   DateTime
     status      BorrowRequestStatus @default(PENDING)

--- a/backend/src/routers/borrowRouter.ts
+++ b/backend/src/routers/borrowRouter.ts
@@ -161,8 +161,8 @@ borrowRouter.get('/list', async (_, res) => {
 const formatBookings = (bookings: any[]) => {
 	return bookings.map((booking) => ({
 		id: booking.id,
-		gameName: booking.game['name'],
-		user: booking.user,
+		gameName: booking.game.name,
+		user: booking.user.cid,
 		borrowStart: booking.borrowStart,
 		borrowEnd: booking.borrowEnd,
 		returned: booking.returned

--- a/backend/src/routers/gameRouter.ts
+++ b/backend/src/routers/gameRouter.ts
@@ -355,8 +355,8 @@ const formatGames = async (games: any[], user: GammaUser | null) => {
 			location: game.location,
 			owner: await getGameOwnerNameFromId(game.gameOwnerId),
 			isBorrowed:
-				game.borrow.filter((b: { returned: boolean }) => {
-					return !b.returned;
+				game.request.filter((b: { status: BorrowRequestStatus }) => {
+					return b.status === BorrowRequestStatus.BORROWED;
 				}).length > 0,
 			ratingAvg: await getAverageRating(game.id),
 			ratingUser: user ? await getUserRating(game.id, user.cid) : null,

--- a/backend/src/routers/gameRouter.ts
+++ b/backend/src/routers/gameRouter.ts
@@ -21,6 +21,7 @@ import {
 import { platformExists } from '../services/platformService.js';
 import { getAverageRating, getUserRating } from '../services/ratingService.js';
 import sendApiValidationError from '../utils/sendApiValidationError.js';
+import { BorrowRequestStatus } from '@prisma/client';
 
 const gameRouter = Router();
 

--- a/backend/src/services/borrowRequestService.ts
+++ b/backend/src/services/borrowRequestService.ts
@@ -22,14 +22,19 @@ export const createBorrowRequest = async (
 ) => {
 	if (borrowStart < new Date(new Date().toDateString()))
 		return BorrowRequestState.InPast;
+
 	if (borrowEnd < borrowStart) return BorrowRequestState.Inverted;
+
 	const borrowRequestStatus = await controlBorrowRequestStatus(
 		gameId,
 		borrowStart,
 		borrowEnd
 	);
+
 	const gammaUser = await getAccountFromCid(user);
+
 	const userId = gammaUser!.id;
+
 	if (borrowRequestStatus == BorrowRequestState.Free) {
 		await prisma.borrowRequest.create({
 			data: {
@@ -40,6 +45,7 @@ export const createBorrowRequest = async (
 			}
 		});
 	}
+
 	return borrowRequestStatus;
 };
 

--- a/backend/src/services/borrowRequestService.ts
+++ b/backend/src/services/borrowRequestService.ts
@@ -1,127 +1,145 @@
 import { prisma } from '../prisma.js';
 import { BorrowRequestStatus } from '@prisma/client';
 import { BorrowStatus } from './borrowService.js';
+import { getAccountFromCid } from './accountService.js';
 
 export enum BorrowRequestState {
-    Pending,
-    Approved,
-    Rejected,
-    Free,
-    Overlapping,
-    Inverted,
-    InPast,
-    NotValid
+	Pending,
+	Approved,
+	Rejected,
+	Free,
+	Overlapping,
+	Inverted,
+	InPast,
+	NotValid
 }
 
 export const createBorrowRequest = async (
-    gameId: string,
-    user: string,
-    borrowStart: Date,
-    borrowEnd: Date
+	gameId: string,
+	user: string,
+	borrowStart: Date,
+	borrowEnd: Date
 ) => {
-    if (borrowStart < new Date(new Date().toDateString())) return BorrowRequestState.InPast;
-    if (borrowEnd < borrowStart) return BorrowRequestState.Inverted;
-    const borrowRequestStatus = await controlBorrowRequestStatus(gameId, borrowStart, borrowEnd);
-    if (borrowRequestStatus == BorrowRequestState.Free) {
-        await prisma.borrowRequest.create({
-            data: {
-                gameId,
-                user,
-                borrowStart,
-                borrowEnd
-            }
-        });
-    }
-    return borrowRequestStatus;
+	if (borrowStart < new Date(new Date().toDateString()))
+		return BorrowRequestState.InPast;
+	if (borrowEnd < borrowStart) return BorrowRequestState.Inverted;
+	const borrowRequestStatus = await controlBorrowRequestStatus(
+		gameId,
+		borrowStart,
+		borrowEnd
+	);
+	const gammaUser = await getAccountFromCid(user);
+	const userId = gammaUser!.id;
+	if (borrowRequestStatus == BorrowRequestState.Free) {
+		await prisma.borrowRequest.create({
+			data: {
+				gameId,
+				userId,
+				borrowStart,
+				borrowEnd
+			}
+		});
+	}
+	return borrowRequestStatus;
 };
 
 export const respondBorrowRequest = async (
-    gameId: string,
-    borrowStart: Date,
-    borrowEnd: Date,
-    approved: boolean
+	gameId: string,
+	borrowStart: Date,
+	borrowEnd: Date,
+	approved: boolean
 ) => {
-    let borrowRequestStatus = await controlBorrowRequestStatus(gameId, borrowStart, borrowEnd);
-    if (borrowRequestStatus == BorrowRequestState.Pending) {
-        await prisma.borrowRequest.updateMany({
-            where: {
-                gameId: gameId,
-                borrowStart: borrowStart,
-                borrowEnd: borrowEnd
-            },
-            data: {
-                status: approved ? BorrowRequestStatus.ACCEPTED : BorrowRequestStatus.REJECTED
-            }
-        });
-        borrowRequestStatus = approved ? BorrowRequestState.Approved : BorrowRequestState.Rejected;
-        let borrowRequest = await prisma.borrowRequest.findFirst({
-            where: {
-                gameId: gameId,
-                borrowStart: borrowStart,
-                borrowEnd: borrowEnd
-            }
-        })
-        if (borrowRequest === null) return BorrowRequestState.NotValid;
-    }
-    return borrowRequestStatus;
-}
+	let borrowRequestStatus = await controlBorrowRequestStatus(
+		gameId,
+		borrowStart,
+		borrowEnd
+	);
+	if (borrowRequestStatus == BorrowRequestState.Pending) {
+		await prisma.borrowRequest.updateMany({
+			where: {
+				gameId: gameId,
+				borrowStart: borrowStart,
+				borrowEnd: borrowEnd
+			},
+			data: {
+				status: approved
+					? BorrowRequestStatus.ACCEPTED
+					: BorrowRequestStatus.REJECTED
+			}
+		});
+		borrowRequestStatus = approved
+			? BorrowRequestState.Approved
+			: BorrowRequestState.Rejected;
+		let borrowRequest = await prisma.borrowRequest.findFirst({
+			where: {
+				gameId: gameId,
+				borrowStart: borrowStart,
+				borrowEnd: borrowEnd
+			}
+		});
+		if (borrowRequest === null) return BorrowRequestState.NotValid;
+	}
+	return borrowRequestStatus;
+};
 
 // TODO: Only get requests for game manager once implemented
 export const getActiveBorrowRequests = async () => {
-    return await prisma.borrowRequest.findMany({
-        where: {
-            status: BorrowRequestStatus.PENDING
-        },
-        include: {
-            game: {
-                select: {
-                    name: true
-                }
-            }
-        }
-    });
-}
+	return await prisma.borrowRequest.findMany({
+		where: {
+			status: BorrowRequestStatus.PENDING
+		},
+		include: {
+			game: {
+				select: {
+					name: true
+				}
+			}
+		}
+	});
+};
 
-const controlBorrowRequestStatus = async (gameId: string, borrowStart: Date, borrowEnd: Date) => {
-    const gameData = await prisma.game.findFirst({
-        where: {
-            id: gameId
-        }
-    });
-    if (gameData === null)
-        return BorrowRequestState.NotValid;
+const controlBorrowRequestStatus = async (
+	gameId: string,
+	borrowStart: Date,
+	borrowEnd: Date
+) => {
+	const gameData = await prisma.game.findFirst({
+		where: {
+			id: gameId
+		}
+	});
+	if (gameData === null) return BorrowRequestState.NotValid;
 
 	const data = await prisma.borrowRequest.findFirst({
 		where: {
 			gameId: gameId,
-            borrowStart: borrowStart,
-            borrowEnd: borrowEnd
+			borrowStart: borrowStart,
+			borrowEnd: borrowEnd
 		}
 	});
 	if (data === null) {
-        const rangeData = await prisma.borrowRequest.findMany({
-            where: {
-                gameId: gameId,
-                borrowStart: {
-                    lte: borrowEnd
-                },
-                borrowEnd: {
-                    gte: borrowStart
-                },
-                status: BorrowRequestStatus.ACCEPTED
-            }
-        });
-        if (rangeData.length > 0)
-		    return BorrowRequestState.Overlapping;
-        else return BorrowRequestState.Free;
-    }
-        
-    switch(data.status) {
-        case BorrowRequestStatus.PENDING:
-            return BorrowRequestState.Pending;
-        case BorrowRequestStatus.REJECTED:
-            return BorrowRequestState.Rejected;
-        case BorrowRequestStatus.ACCEPTED:
-            return BorrowRequestState.Approved;
-    }
-}
+		const rangeData = await prisma.borrowRequest.findMany({
+			where: {
+				gameId: gameId,
+				borrowStart: {
+					lte: borrowEnd
+				},
+				borrowEnd: {
+					gte: borrowStart
+				},
+				status: BorrowRequestStatus.ACCEPTED
+			}
+		});
+		if (rangeData.length > 0) return BorrowRequestState.Overlapping;
+		else return BorrowRequestState.Free;
+	}
+
+	switch (data.status) {
+		case BorrowRequestStatus.PENDING:
+			return BorrowRequestState.Pending;
+		case BorrowRequestStatus.REJECTED:
+			return BorrowRequestState.Rejected;
+		case BorrowRequestStatus.ACCEPTED:
+			return BorrowRequestState.Approved;
+	}
+};

--- a/backend/src/services/borrowService.ts
+++ b/backend/src/services/borrowService.ts
@@ -10,14 +10,13 @@ export enum BorrowStatus {
 
 export const borrowGame = async (
 	gameId: string,
-	user: string,
 	borrowStart: Date,
-	borrowEnd: Date
+	borrowEnd: Date,
+	userId: string
 ) => {
-	const borrowStatus = await controlBorrowStatus(gameId, user);
+	const borrowStatus = await controlBorrowStatus(gameId);
+
 	if (borrowStatus == BorrowStatus.NotBorrowed) {
-		const gammaUser = await getAccountFromCid(user);
-		const userId = gammaUser!.id;
 		await prisma.borrowRequest.create({
 			data: {
 				gameId,
@@ -27,11 +26,12 @@ export const borrowGame = async (
 			}
 		});
 	}
+
 	return borrowStatus;
 };
 
 export const returnGame = async (gameId: string, user: string) => {
-	const borrowStatus = await controlBorrowStatus(gameId, user);
+	const borrowStatus = await controlBorrowStatus(gameId);
 	if (borrowStatus == BorrowStatus.Borrowed) {
 		await prisma.game.update({
 			where: {
@@ -72,7 +72,7 @@ export const listBorrows = async () => {
 	return borrows;
 };
 
-const controlBorrowStatus = async (gameId: string, user: string) => {
+const controlBorrowStatus = async (gameId: string) => {
 	const data = await prisma.game.findUnique({
 		where: {
 			id: gameId

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -120,15 +120,11 @@ export const removeGame = async (gameId: string) => {
 			id: gameId
 		},
 		select: {
-			request: true,
-			GameOwner: true
+			request: true
 		}
 	});
 
 	if (!game) throw new Error('Game not found');
-	if (game.GameOwner?.id != gameOwnerId) {
-		throw new Error('User does not own this game');
-	}
 	const borrows = game.request.filter(
 		(request) =>
 			request.status === BorrowRequestStatus.BORROWED &&

--- a/backend/src/services/gameService.ts
+++ b/backend/src/services/gameService.ts
@@ -48,7 +48,7 @@ export const searchAndFilterGames = async (filter?: Filter) => {
 			}
 		},
 		include: {
-			borrow: {}
+			request: {}
 		}
 	});
 };
@@ -130,7 +130,9 @@ export const removeGame = async (gameId: string) => {
 		throw new Error('User does not own this game');
 	}
 	const borrows = game.request.filter(
-		(request) => request.status === BorrowRequestStatus.BORROWED && request.borrowStart < new Date()
+		(request) =>
+			request.status === BorrowRequestStatus.BORROWED &&
+			request.borrowStart < new Date()
 	);
 
 	if (borrows.length > 0) throw new Error('Game is currently borrowed');


### PR DESCRIPTION
## Key features
- Removed `Borrow` from database, merged into `BorrowRequest` along with values `BORROWED` and `RETURNED` for complete state tracking
- Make routers and services use `BorrowRequest` instead
- Check if something is borrowed/returned using the enum instead of what used to be a boolean

## Known issues
- There currently exists no way to actually "go through" and actually borrow or return a game, and an accepted borrow request does not mark a game as borrowed. This should be done as another user story.