### PR TITLE
Only forward needed headers

### DIFF
--- a/frontend/src/utils/loginRedirects.ts
+++ b/frontend/src/utils/loginRedirects.ts
@@ -51,6 +51,11 @@ const getLoginStatus = async (req: IncomingMessage) => {
 		throw new Error('BACKEND_ADDRESS is undefined');
 
 	return await fetch(`${process.env.BACKEND_ADDRESS}/api/v1/auth/user`, {
-		headers: req.headers as HeadersInit
+		headers: {
+			cookie: req.headers.cookie,
+			referer: req.headers.referer,
+			host: req.headers.host,
+			userAgent: req.headers['user-agent']
+		} as HeadersInit
 	});
 };


### PR DESCRIPTION
Originally we forwarded all headers and if a `keep-alive` header is forwarded the frontend crashes.
Now we only keep the required headers.