### PR TITLE
Display proper rating when logged out

### DIFF
--- a/frontend/src/components/GameCard/GameCard.tsx
+++ b/frontend/src/components/GameCard/GameCard.tsx
@@ -59,8 +59,6 @@ const GameRating: FC<GameCardProps> = ({ game }) => {
 	const { mutate } = useAddRating();
 	const { data } = useUser();
 
-	if (!data) return <p>Average rating: {game.ratingAvg}</p>;
-
 	useEffect(() => {
 		if (!ref.current || !game.ratingAvg) return;
 


### PR DESCRIPTION
Previously when logged out, "legacy" UI for displaying average rating would appear instead of the new stars. This PR fixes said issue.

Closes no issues.